### PR TITLE
fix: 重複通知を防止 & CODEOWNERS 追加

### DIFF
--- a/control-plane/db/migrations/018-unique-constraints.sql
+++ b/control-plane/db/migrations/018-unique-constraints.sql
@@ -1,0 +1,18 @@
+-- Add UNIQUE constraints to prevent duplicate records
+-- This migration adds constraints to:
+-- 1. grounds: prevent duplicate ground names per municipality
+-- 2. watch_conditions: prevent duplicate conditions (same team + facility)
+
+-- Create unique index on grounds (municipality_id, name)
+-- This prevents auto-created grounds from creating duplicates
+CREATE UNIQUE INDEX IF NOT EXISTS idx_grounds_municipality_name 
+  ON grounds(municipality_id, name);
+
+-- Create unique index on watch_conditions (team_id, facility_id)
+-- This prevents duplicate watch conditions for the same team+facility
+CREATE UNIQUE INDEX IF NOT EXISTS idx_watch_conditions_team_facility 
+  ON watch_conditions(team_id, facility_id) WHERE enabled = 1;
+
+-- Record execution of this migration
+INSERT OR IGNORE INTO migrations (migration_number, migration_name)
+VALUES (018, '018-unique-constraints');


### PR DESCRIPTION
## 変更内容

### 1. 重複通知の修正
- `grounds` テーブルに `(municipality_id, name)` の UNIQUE INDEX を追加
- `watch_conditions` テーブルに `(team_id, facility_id)` の UNIQUE INDEX を追加
- 本番 DB の重複データは手動で修正済み

### 2. CODEOWNERS 追加
- すべてのコード変更に @susumutomita の承認が必須

## 背景
同じグラウンドに対して重複した通知が送信されていた問題を修正。
原因は `watch_conditions` と `grounds` テーブルに重複レコードが存在していたため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database constraints to enforce data uniqueness for grounds within municipalities and active watch conditions per team and facility, preventing duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->