### PR TITLE
fix: Worker 起動時に DB マイグレーションを自動実行

### DIFF
--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"akigura.dev/worker"
+	"akigura.dev/worker/dbmigrate"
 	"akigura.dev/worker/notifier"
 	"akigura.dev/worker/scraper"
 	_ "github.com/tursodatabase/libsql-client-go/libsql"
@@ -31,6 +32,7 @@ var (
 	flagJobMode        = flag.Bool("job-mode", false, "process pending jobs from database")
 	flagNative         = flag.Bool("native", false, "use native Go scrapers instead of Python")
 	flagScraperType    = flag.String("scraper-type", "", "specific scraper to run (kanagawa, hiratsuka, yokohama)")
+	flagMigrationsDir  = flag.String("migrations-dir", "../control-plane/db/migrations", "path to SQL migration files (empty to skip)")
 )
 
 func main() {
@@ -48,6 +50,13 @@ func run() error {
 		return fmt.Errorf("open database: %w", err)
 	}
 	defer db.Close()
+
+	// Run migrations before any queries
+	if *flagMigrationsDir != "" {
+		if err := dbmigrate.RunMigrations(db, *flagMigrationsDir); err != nil {
+			return fmt.Errorf("run migrations: %w", err)
+		}
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/worker/dbmigrate/migrate.go
+++ b/worker/dbmigrate/migrate.go
@@ -1,0 +1,92 @@
+package dbmigrate
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+)
+
+// RunMigrations reads SQL migration files from the given directory
+// and executes them in numeric order against the database.
+// Migration files must match the pattern NNN-*.sql (e.g., 001-base.sql).
+func RunMigrations(db *sql.DB, migrationsDir string) error {
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("read migrations dir %s: %w", migrationsDir, err)
+	}
+
+	pat := regexp.MustCompile(`^(\d{3})-.*\.sql$`)
+	var migrations []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if pat.MatchString(e.Name()) {
+			migrations = append(migrations, e.Name())
+		}
+	}
+	sort.Strings(migrations)
+
+	// Check which migrations have already been executed
+	executed := make(map[int]bool)
+	var tableName string
+	err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='migrations'").Scan(&tableName)
+	switch {
+	case err == nil:
+		rows, err := db.Query("SELECT migration_number FROM migrations")
+		if err != nil {
+			return fmt.Errorf("query executed migrations: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var n int
+			if err := rows.Scan(&n); err != nil {
+				return fmt.Errorf("scan migration number: %w", err)
+			}
+			executed[n] = true
+		}
+	case errors.Is(err, sql.ErrNoRows):
+		slog.Info("db: migrations table not found; running all migrations")
+	default:
+		return fmt.Errorf("check migrations table: %w", err)
+	}
+
+	applied := 0
+	for _, m := range migrations {
+		match := pat.FindStringSubmatch(m)
+		if len(match) != 2 {
+			return fmt.Errorf("invalid migration filename: %s", m)
+		}
+		n, err := strconv.Atoi(match[1])
+		if err != nil {
+			return fmt.Errorf("parse migration number %s: %w", m, err)
+		}
+		if executed[n] {
+			continue
+		}
+
+		content, err := os.ReadFile(filepath.Join(migrationsDir, m))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", m, err)
+		}
+		if _, err := db.Exec(string(content)); err != nil {
+			return fmt.Errorf("exec %s: %w", m, err)
+		}
+		applied++
+		slog.Info("db: applied migration", "file", m, "number", n)
+	}
+
+	if applied > 0 {
+		slog.Info("db: migrations complete", "applied", applied, "total", len(migrations))
+	} else {
+		slog.Info("db: all migrations already applied", "total", len(migrations))
+	}
+
+	return nil
+}

--- a/worker/dbmigrate/migrate_test.go
+++ b/worker/dbmigrate/migrate_test.go
@@ -1,0 +1,76 @@
+package dbmigrate
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+const migrationsDir = "../../control-plane/db/migrations"
+
+func TestRunMigrations(t *testing.T) {
+	if _, err := os.Stat(migrationsDir); os.IsNotExist(err) {
+		t.Skip("migrations directory not found (expected in monorepo layout)")
+	}
+
+	t.Run("空のデータベースに全マイグレーションを適用すべき", func(t *testing.T) {
+		db, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		if err := RunMigrations(db, migrationsDir); err != nil {
+			t.Fatalf("RunMigrations failed: %v", err)
+		}
+
+		// Verify migrations table exists and has entries
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM migrations").Scan(&count); err != nil {
+			t.Fatalf("query migrations count: %v", err)
+		}
+		if count == 0 {
+			t.Error("migrations table should have entries after running migrations")
+		}
+
+		// Verify key tables exist
+		for _, table := range []string{"municipalities", "grounds", "slots", "scrape_jobs"} {
+			var name string
+			err := db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&name)
+			if err != nil {
+				t.Errorf("table %s should exist after migrations: %v", table, err)
+			}
+		}
+	})
+
+	t.Run("既に適用済みのマイグレーションをスキップすべき", func(t *testing.T) {
+		db, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		// Run twice -- second run should be a no-op
+		if err := RunMigrations(db, migrationsDir); err != nil {
+			t.Fatalf("first RunMigrations failed: %v", err)
+		}
+		if err := RunMigrations(db, migrationsDir); err != nil {
+			t.Fatalf("second RunMigrations (idempotent) failed: %v", err)
+		}
+	})
+
+	t.Run("存在しないディレクトリでエラーを返すべき", func(t *testing.T) {
+		db, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+
+		err = RunMigrations(db, "/nonexistent/path")
+		if err == nil {
+			t.Error("RunMigrations should fail for nonexistent directory")
+		}
+	})
+}


### PR DESCRIPTION
## 概要

scrape ワークフローが 43 日間連続で失敗していた問題を修正。Worker 起動時に DB マイグレーションを自動実行するようにした。

## 原因

- エラー: `SQL logic error: no such table: municipalities (1)`
- マイグレーションは control-plane サーバー起動時にのみ実行されており、Worker 単体では DB スキーマを復旧できなかった
- Turso DB のテーブルが消失した際に、Worker だけが動く CI 環境では永続的に失敗し続ける状態だった

## 変更内容

- `worker/dbmigrate/` パッケージを新規追加: ランタイムで `control-plane/db/migrations/` の SQL ファイルを読み込んで実行
- `--migrations-dir` フラグを追加（デフォルト: `../control-plane/db/migrations`）
- DB 接続直後、クエリ実行前にマイグレーションを実行

## テスト

- `go test ./dbmigrate/ -v` 全パス（3件）
  - 空の DB に全 18 マイグレーションを適用
  - 適用済みマイグレーションのスキップ（冪等性）
  - 存在しないディレクトリでのエラーハンドリング
- `go build ./cmd/worker` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database migrations can now be automatically applied when the worker starts.
  * New command-line option to enable migrations with a custom directory path.
  * Migrations are tracked to prevent duplicate execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->